### PR TITLE
Add sentence image recall prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ dist-ssr
 .mcp.json
 *.local
 
+# Throwaway sentence-image workflow prototype
+prototypes/sentence-image-workflow/.poc-data/
+
 # Turborepo
 .turbo
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
+  "ignoreBinaries": ["open"],
 
   "workspaces": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "coverage": "vitest run --coverage",
     "format": "prettier --check \"src/**/*.{ts,tsx,js,jsx,css}\" \"convex/**/*.{ts,tsx}\"",
     "knip": "knip",
+    "prototype:sentence-image": "tsx prototypes/sentence-image-workflow/cli.ts",
     "change-password": "tsx src/scripts/changePassword.ts",
     "check": "./scripts/check-local.sh",
     "check:all": "./scripts/check-local.sh --all",

--- a/prototypes/sentence-image-workflow/NOTES.md
+++ b/prototypes/sentence-image-workflow/NOTES.md
@@ -1,0 +1,23 @@
+# Prototype verdict
+
+Observed result from the PoC runs:
+
+- Choosing among complete sentences feels better than choosing a target
+  expression. The useful unit is the whole sentence, especially when each
+  option has a clear style label and CEFR level.
+- Sentence feedback needs a strict prompt. Good output included phrase-level
+  diagnosis, no weak collocations like "by chip," and no invented facts such as
+  repeated failures.
+- The image cue works when the chosen sentence is concrete. For "I got a
+  replacement card because the chip wasn't working," the cue clearly showed a
+  failed card chip and a replacement card.
+- Image prompting must explicitly ban readable symbols, not only text. The
+  first useful image still used X marks; the stricter prompt produced a better
+  text-free illustration with visual storytelling instead.
+- Exact recall works technically, but it is strict. A real English Punch
+  feature would probably need fuzzy comparison, typo tolerance, and a reveal
+  flow that highlights the missing or changed words.
+- Saving each chosen item as `.poc-data/items/<id>.json` plus `<id>.png` is the
+  right next PoC shape. The durable item only needs `chosen` and `imagePath`;
+  the original sentence and evaluation are useful during selection, but not
+  necessary for later recall.

--- a/prototypes/sentence-image-workflow/README.md
+++ b/prototypes/sentence-image-workflow/README.md
@@ -1,0 +1,36 @@
+# Sentence → Image → Recall prototype
+
+**Question:** Does a sentence-first learning loop feel useful when ChatGPT
+offers several complete rewrites, the learner chooses one, and a text-free
+image cues recall—without extracting a target expression or changing English
+Punch?
+
+This is throwaway logic/UI code. It keeps active workflow state in memory, then
+writes each chosen quiz item to `.poc-data/items/<id>.json` and
+`.poc-data/items/<id>.png`. The directory is ignored by Git.
+
+Run it from the repository root:
+
+```bash
+pnpm run prototype:sentence-image
+```
+
+The prototype opens a visible, persistent Chrome session at ChatGPT. Complete
+any Cloudflare check or login in that window, then return to the terminal. The
+sentence you enter is sent to ChatGPT for evaluation and image generation.
+
+Sentence evaluation switches ChatGPT to `Extra High` intelligence and returns
+four natural alternatives at CEFR B1, B2, C1, and C2 levels. Image generation
+switches back to `Instant`, requests a text-free 2D illustration, and saves the
+original authenticated image download rather than a page screenshot.
+
+Each saved JSON item contains only the chosen sentence and the generated image
+path. The original sentence and evaluation stay in the live terminal workflow
+but are not persisted.
+
+The browser automation intentionally uses the existing `playwright-cli`
+installation instead of adding Playwright as a project dependency. The UI
+selectors are exploratory and may need to change as ChatGPT evolves.
+
+Delete or absorb this prototype after deciding whether the whole-sentence
+image cue is useful.

--- a/prototypes/sentence-image-workflow/chatgpt.ts
+++ b/prototypes/sentence-image-workflow/chatgpt.ts
@@ -1,0 +1,239 @@
+import { spawnSync } from "node:child_process";
+
+import type { Candidate, Evaluation, FeedbackPoint } from "./workflow.ts";
+
+const SESSION = "ep-poc";
+const PLAYWRIGHT = "playwright-cli";
+
+type Pause = (message: string) => Promise<void>;
+
+function playwright(args: string[], raw = true): string {
+  const result = spawnSync(
+    PLAYWRIGHT,
+    [...(raw ? ["--raw"] : []), `-s=${SESSION}`, ...args],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, TMPDIR: "/tmp" },
+      maxBuffer: 10 * 1024 * 1024,
+    }
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      (result.stderr || result.stdout || "Playwright failed.").trim()
+    );
+  }
+
+  return result.stdout.trim();
+}
+
+function promptBoxExists(): boolean {
+  try {
+    return (
+      playwright([
+        "eval",
+        "Boolean(document.querySelector('#prompt-textarea'))",
+      ]) === "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureChatGptReady(pause: Pause): Promise<void> {
+  if (!promptBoxExists()) {
+    try {
+      playwright(
+        [
+          "open",
+          "https://chatgpt.com/",
+          "--browser=chrome",
+          "--persistent",
+          "--headed",
+        ],
+        false
+      );
+    } catch (error) {
+      if (!String(error).includes("already open")) {
+        throw error;
+      }
+    }
+  }
+
+  if (!promptBoxExists()) {
+    await pause(
+      "Complete any Cloudflare check or ChatGPT login in the opened browser, then press Enter here."
+    );
+  }
+
+  if (!promptBoxExists()) {
+    throw new Error("ChatGPT is not ready: the prompt box could not be found.");
+  }
+}
+
+function validateEvaluation(value: unknown): Evaluation {
+  if (!value || typeof value !== "object") {
+    throw new Error("ChatGPT returned invalid JSON.");
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.summary !== "string" ||
+    !Array.isArray(candidate.points) ||
+    !Array.isArray(candidate.candidates)
+  ) {
+    throw new Error("ChatGPT returned an incomplete evaluation.");
+  }
+
+  const points = candidate.points.filter((item): item is FeedbackPoint =>
+    Boolean(
+      item &&
+      typeof item === "object" &&
+      typeof (item as FeedbackPoint).excerpt === "string" &&
+      typeof (item as FeedbackPoint).explanation === "string"
+    )
+  );
+
+  if (points.length < 2 || points.length > 4) {
+    throw new Error("ChatGPT did not return two to four feedback points.");
+  }
+
+  const candidates = candidate.candidates.filter((item): item is Candidate =>
+    Boolean(
+      item &&
+      typeof item === "object" &&
+      typeof (item as Candidate).style === "string" &&
+      typeof (item as Candidate).level === "string" &&
+      typeof (item as Candidate).sentence === "string"
+    )
+  );
+
+  if (candidates.length !== 4) {
+    throw new Error("ChatGPT did not return exactly four sentence options.");
+  }
+
+  return {
+    summary: candidate.summary,
+    points,
+    candidates,
+  };
+}
+
+export function evaluateSentence(sentence: string): Evaluation {
+  const coachPrompt = `You are an expert English writing coach. Analyze the learner's intended meaning, grammar, collocations, vocabulary, register, and naturalness with care. Evaluate the writing as a complete sentence or connected thought, without selecting or teaching a target expression.
+
+Learner sentence: ${JSON.stringify(sentence)}
+
+Return only valid JSON with this exact shape:
+{"summary":"A concise overall evaluation in one or two sentences.","points":[{"excerpt":"An exact phrase quoted from the learner's sentence.","explanation":"A specific explanation of what works or sounds unnatural, why, and one or two more natural choices."}],"candidates":[{"style":"A short descriptive label such as Direct & Natural, Focusing on the issue, Advanced & Concise, or Action-oriented.","level":"A CEFR label such as B1, B2, C1, C1/C2, or C2.","sentence":"One complete natural alternative."}]}
+
+Quality requirements:
+- Write two to four phrase-level feedback points. Quote the learner's exact wording in each excerpt.
+- Give each feedback point a distinct purpose. Merge overlapping observations instead of analyzing the same phrase or ambiguity twice; for a single sentence, three substantial points are usually better than four repetitive ones.
+- Diagnose the real issue precisely: grammar, collocation, ambiguity, direct translation, redundancy, technical wording, or register. Do not call a phrase incorrect when it is merely formal or less idiomatic.
+- When useful, contrast the learner's phrase with natural alternatives and explain the nuance briefly.
+- Recommend only expressions and collocations you are highly confident a native speaker would actually use. Do not offer a shorter preposition phrase merely because it is grammatically possible. Prefer ordinary idiomatic wording unless the context genuinely calls for technical language.
+- For card-payment chip problems, prefer everyday phrases such as 'using the chip,' 'the chip wasn't working,' 'the reader couldn't read the chip,' or 'the payment wouldn't go through.' Do not recommend bare phrases like 'by chip,' 'with chip,' or technical phrases like 'chip payment function' unless the learner is writing for a technical support document.
+- Produce exactly four alternatives spanning roughly B1 to C2.
+- Make the four alternatives meaningfully different in style, syntax, focus, or register. At minimum include a direct natural version, a version that shifts focus or perspective, a concise advanced version, and one other context-appropriate angle such as action-oriented, conversational, professional, narrative, or empathetic.
+- Choose style labels that accurately describe the specific alternative; do not mechanically reuse labels that do not fit the content.
+- Keep every alternative faithful to the original event, facts, tone, and likely intended meaning. When a vague pronoun's referent is strongly implied by context, make that noun explicit in at least two alternatives; otherwise preserve the ambiguity rather than inventing a detail.
+- Do not add frequency, duration, severity, or certainty that the learner did not state. Avoid words like 'repeated,' 'frequent,' 'ongoing,' 'constant,' 'serious,' or 'faulty' unless they are clearly supported by the learner's sentence.
+- Higher levels should improve fluency, precision, and nuance rather than merely use longer or rarer words.
+- Do not simulate advanced English with unnecessary nominalizations or technical noun phrases. The advanced concise alternative should be genuinely compact, idiomatic, and precise.
+- Every candidate must be memorable and sound like something a native speaker would genuinely say or write.
+- Return strictly parseable JSON. Before responding, silently verify that JSON.parse would succeed. Prefer single quotation marks around English examples inside JSON string values; if a double quotation mark appears inside a string value, escape it as \\". The excerpt value itself must contain the exact phrase without surrounding quotation marks.
+- Do not use Markdown or include any text outside the JSON.`;
+
+  const code = `async page => {
+    const prompt = ${JSON.stringify(coachPrompt)};
+    const intelligence = page.getByRole('button', { name: /^(Instant|Medium|High|Extra High|Pro)$/ });
+    if ((await intelligence.innerText()).trim() !== 'Extra High') {
+      await intelligence.click();
+      await page.getByRole('menuitemradio', { name: 'Extra High' }).click();
+      await page.getByRole('button', { name: 'Extra High', exact: true }).waitFor();
+    }
+    const messages = page.locator('[data-message-author-role="assistant"]');
+    const before = await messages.count();
+    const box = page.locator('#prompt-textarea');
+    await box.fill(prompt);
+    await page.getByTestId('send-button').click();
+    await page.waitForFunction((count) => {
+      const all = [...document.querySelectorAll('[data-message-author-role="assistant"]')];
+      if (all.length <= count) return false;
+      const text = all.at(-1)?.textContent?.trim() ?? '';
+      const fence = String.fromCharCode(96).repeat(3);
+      const clean = text.trim().replace(new RegExp('^' + fence + '(?:json)?\\\\s*', 'i'), '').replace(new RegExp(fence + '$'), '').trim();
+      try { JSON.parse(clean); return true; } catch { return false; }
+    }, before, { timeout: 240000 });
+    const text = (await messages.last().innerText()).trim();
+    const fence = String.fromCharCode(96).repeat(3);
+    const clean = text.trim().replace(new RegExp('^' + fence + '(?:json)?\\\\s*', 'i'), '').replace(new RegExp(fence + '$'), '').trim();
+    return JSON.parse(clean);
+  }`;
+
+  const output = playwright(["run-code", code]);
+  return validateEvaluation(JSON.parse(output));
+}
+
+export function generateCueImage(sentence: string, imagePath: string): string {
+  const imagePrompt = `Create one memorable 2D illustration as a visual cue for recalling this complete English sentence: ${JSON.stringify(sentence)}
+
+Use a clean contemporary editorial or storybook style: simplified shapes, expressive characters, crisp silhouettes, warm colors, and a subtle hand-drawn texture. Make it clearly illustrated, not photorealistic and not a 3D render.
+
+Depict the event literally in one simple, intuitive scene. Include every concrete detail needed to distinguish this sentence from similar ones. Do not include any written language or readable symbols: no words, letters, numbers, X marks, checkmarks, captions, subtitles, speech bubbles, signs, labels, logos, interface text, currency marks, or watermarks. Show payment failure through visual storytelling instead, such as a dark or blank card reader screen, a confused expression, an unread chip, or a declined gesture.`;
+
+  const code = `async page => {
+    const prompt = ${JSON.stringify(imagePrompt)};
+    const outputPath = ${JSON.stringify(imagePath)};
+    const intelligence = page.getByRole('button', { name: /^(Instant|Medium|High|Extra High|Pro)$/ });
+    if ((await intelligence.innerText()).trim() !== 'Instant') {
+      await intelligence.click();
+      await page.getByRole('menuitemradio', { name: /^Instant/ }).click();
+      await page.getByRole('button', { name: 'Instant', exact: true }).waitFor();
+    }
+    const generatedImages = page.locator('img[alt^="Generated image:"]');
+    const before = await generatedImages.count();
+    const box = page.locator('#prompt-textarea');
+    await box.fill(prompt);
+    await page.getByTestId('send-button').click();
+    await page.waitForFunction((count) => {
+      const images = [...document.querySelectorAll('img[alt^="Generated image:"]')];
+      return images.length > count && images.at(-1).naturalWidth >= 256 && images.at(-1).naturalHeight >= 256;
+    }, before, { timeout: 240000 });
+
+    const source = await generatedImages.last().evaluate(image => image.currentSrc);
+    const downloadPromise = page.waitForEvent('download');
+    await page.evaluate(async imageSource => {
+      const response = await fetch(imageSource);
+      if (!response.ok) throw new Error('Image download failed: ' + response.status);
+
+      const objectUrl = URL.createObjectURL(await response.blob());
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = 'current-cue.png';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+    }, source);
+
+    const download = await downloadPromise;
+    await download.saveAs(outputPath);
+    const failure = await download.failure();
+    if (failure) throw new Error('Image download failed: ' + failure);
+    return outputPath;
+  }`;
+
+  const output = playwright(["run-code", code]);
+  return output.replace(/^"|"$/g, "");
+}
+
+export function closeBrowser(): void {
+  try {
+    playwright(["close"], false);
+  } catch {
+    // The session may already be closed.
+  }
+}

--- a/prototypes/sentence-image-workflow/cli.ts
+++ b/prototypes/sentence-image-workflow/cli.ts
@@ -1,0 +1,188 @@
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+import {
+  closeBrowser,
+  ensureChatGptReady,
+  evaluateSentence,
+  generateCueImage,
+} from "./chatgpt.ts";
+import { createQuizItemPaths, saveQuizItem } from "./storage.ts";
+import { initialState, transition, type WorkflowState } from "./workflow.ts";
+
+const bold = "\u001B[1m";
+const dim = "\u001B[2m";
+const reset = "\u001B[0m";
+const input = createInterface({ input: stdin, output: stdout });
+
+function render(state: WorkflowState, notice?: string): void {
+  console.clear();
+  console.log(`${bold}PROTOTYPE — Sentence → Image → Recall${reset}`);
+  console.log(
+    `${dim}No target expression. No database. Scratch image only.${reset}\n`
+  );
+  console.log(`${bold}step${reset}: ${state.step}`);
+
+  if ("original" in state) {
+    console.log(`${bold}original${reset}: ${state.original}`);
+  }
+  if ("evaluation" in state) {
+    console.log(`\n${bold}Grammar and Vocabulary Evaluation${reset}\n`);
+    console.log(state.evaluation.summary);
+    for (const point of state.evaluation.points) {
+      console.log(`\n${bold}"${point.excerpt}"${reset}: ${point.explanation}`);
+    }
+  }
+  if ("chosen" in state) {
+    console.log(`${bold}chosen${reset}: ${state.chosen.sentence}`);
+  }
+  if ("imagePath" in state) {
+    console.log(`${bold}image${reset}: ${state.imagePath}`);
+  }
+  if ("itemPath" in state) {
+    console.log(`${bold}item${reset}: ${state.itemPath}`);
+  }
+  if (state.step === "revealed") {
+    console.log(`${bold}your recall${reset}: ${state.recall}`);
+    console.log(
+      `${bold}exact match${reset}: ${state.recall === state.chosen.sentence ? "yes" : "no"}`
+    );
+  }
+  if (notice) {
+    console.log(`\n${notice}`);
+  }
+}
+
+async function pause(message: string): Promise<void> {
+  await input.question(`\n${message} `);
+}
+
+function openImage(path: string): void {
+  spawnSync("open", [path], { stdio: "ignore" });
+}
+
+async function main(): Promise<void> {
+  let state: WorkflowState = initialState;
+
+  while (true) {
+    render(state);
+
+    if (state.step === "writing") {
+      const sentence = await input.question(
+        `\n${bold}Write one sentence${reset} ([q] quit): `
+      );
+      if (sentence.trim().toLowerCase() === "q") {
+        break;
+      }
+
+      state = transition(state, { type: "submit-sentence", sentence });
+      render(state, "Opening ChatGPT for evaluation…");
+
+      try {
+        await ensureChatGptReady(pause);
+        const evaluation = evaluateSentence(sentence.trim());
+        state = transition(state, { type: "receive-evaluation", evaluation });
+      } catch (error) {
+        render(state, `${bold}Automation stopped:${reset} ${String(error)}`);
+        await pause("Press Enter to start over.");
+        state = transition(state, { type: "restart" });
+      }
+      continue;
+    }
+
+    if (state.step === "choosing") {
+      console.log(`\n${bold}Natural Alternatives (B1–C2)${reset}`);
+      console.log(
+        state.evaluation.candidates
+          .map(
+            (candidate, index) =>
+              `${bold}[${index + 1}]${reset} ${candidate.style} (${candidate.level}): "${candidate.sentence}"`
+          )
+          .join("\n")
+      );
+      const choice = await input.question(`\nChoose 1–4 ([q] quit): `);
+      if (choice.trim().toLowerCase() === "q") {
+        break;
+      }
+      const index = Number(choice) - 1;
+
+      try {
+        const chosen = state.evaluation.candidates[index];
+        if (!chosen) {
+          throw new Error("Choose sentence 1, 2, 3, or 4.");
+        }
+        state = transition(state, { type: "choose", index });
+        render(state, "Asking ChatGPT to generate a text-free image…");
+        const paths = createQuizItemPaths();
+        const imagePath = generateCueImage(chosen.sentence, paths.imagePath);
+        saveQuizItem({
+          chosen,
+          imagePath,
+          itemPath: paths.itemPath,
+        });
+        state = transition(state, {
+          type: "receive-image",
+          imagePath,
+          itemPath: paths.itemPath,
+        });
+      } catch (error) {
+        render(state, `${bold}Automation stopped:${reset} ${String(error)}`);
+        await pause("Press Enter to start over.");
+        state = transition(state, { type: "restart" });
+      }
+      continue;
+    }
+
+    if (state.step === "image-ready") {
+      const imagePath = state.imagePath;
+      const action = await input.question(
+        `\n${bold}[v]${reset} view cue  ${bold}[r]${reset} recall quiz  ${bold}[n]${reset} new sentence  ${bold}[q]${reset} quit: `
+      );
+      if (action === "q") {
+        break;
+      }
+      if (action === "n") {
+        state = transition(state, { type: "restart" });
+      }
+      if (action === "v") {
+        openImage(imagePath);
+      }
+      if (action === "r") {
+        openImage(imagePath);
+        state = transition(state, { type: "start-quiz" });
+      }
+      continue;
+    }
+
+    if (state.step === "recalling") {
+      const recall = await input.question(`\nType the complete sentence: `);
+      state = transition(state, { type: "submit-recall", recall });
+      continue;
+    }
+
+    if (state.step === "revealed") {
+      const imagePath = state.imagePath;
+      const action = await input.question(
+        `\n${bold}[n]${reset} new sentence  ${bold}[v]${reset} view cue  ${bold}[q]${reset} quit: `
+      );
+      if (action === "q") {
+        break;
+      }
+      if (action === "n") {
+        state = transition(state, { type: "restart" });
+      }
+      if (action === "v") {
+        openImage(imagePath);
+      }
+      continue;
+    }
+  }
+}
+
+try {
+  await main();
+} finally {
+  input.close();
+  closeBrowser();
+}

--- a/prototypes/sentence-image-workflow/storage.ts
+++ b/prototypes/sentence-image-workflow/storage.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import type { Candidate } from "./workflow.ts";
+
+export type QuizItem = {
+  chosen: string;
+  imagePath: string;
+};
+
+export type QuizItemPaths = {
+  id: string;
+  itemPath: string;
+  imagePath: string;
+};
+
+const dataDirectory = path.resolve(
+  process.cwd(),
+  "prototypes/sentence-image-workflow/.poc-data/items"
+);
+
+export function createQuizItemPaths(): QuizItemPaths {
+  const id = randomUUID();
+  mkdirSync(dataDirectory, { recursive: true });
+
+  return {
+    id,
+    itemPath: path.join(dataDirectory, `${id}.json`),
+    imagePath: path.join(dataDirectory, `${id}.png`),
+  };
+}
+
+export function saveQuizItem(input: {
+  chosen: Candidate;
+  imagePath: string;
+  itemPath: string;
+}): QuizItem {
+  const item: QuizItem = {
+    chosen: input.chosen.sentence,
+    imagePath: input.imagePath,
+  };
+
+  writeFileSync(input.itemPath, `${JSON.stringify(item, null, 2)}\n`);
+  return item;
+}

--- a/prototypes/sentence-image-workflow/workflow.ts
+++ b/prototypes/sentence-image-workflow/workflow.ts
@@ -1,0 +1,128 @@
+export type Candidate = {
+  style: string;
+  level: string;
+  sentence: string;
+};
+
+export type FeedbackPoint = {
+  excerpt: string;
+  explanation: string;
+};
+
+export type Evaluation = {
+  summary: string;
+  points: FeedbackPoint[];
+  candidates: Candidate[];
+};
+
+export type WorkflowState =
+  | { step: "writing" }
+  | { step: "evaluating"; original: string }
+  | { step: "choosing"; original: string; evaluation: Evaluation }
+  | {
+      step: "generating-image";
+      original: string;
+      evaluation: Evaluation;
+      chosen: Candidate;
+    }
+  | {
+      step: "image-ready";
+      original: string;
+      evaluation: Evaluation;
+      chosen: Candidate;
+      imagePath: string;
+      itemPath: string;
+    }
+  | {
+      step: "recalling";
+      original: string;
+      evaluation: Evaluation;
+      chosen: Candidate;
+      imagePath: string;
+      itemPath: string;
+    }
+  | {
+      step: "revealed";
+      original: string;
+      evaluation: Evaluation;
+      chosen: Candidate;
+      imagePath: string;
+      itemPath: string;
+      recall: string;
+    };
+
+export type WorkflowAction =
+  | { type: "submit-sentence"; sentence: string }
+  | { type: "receive-evaluation"; evaluation: Evaluation }
+  | { type: "choose"; index: number }
+  | { type: "receive-image"; imagePath: string; itemPath: string }
+  | { type: "start-quiz" }
+  | { type: "submit-recall"; recall: string }
+  | { type: "restart" };
+
+export const initialState: WorkflowState = { step: "writing" };
+
+export function transition(
+  state: WorkflowState,
+  action: WorkflowAction
+): WorkflowState {
+  if (action.type === "restart") {
+    return initialState;
+  }
+
+  switch (state.step) {
+    case "writing":
+      if (action.type === "submit-sentence" && action.sentence.trim()) {
+        return { step: "evaluating", original: action.sentence.trim() };
+      }
+      break;
+
+    case "evaluating":
+      if (action.type === "receive-evaluation") {
+        return {
+          step: "choosing",
+          original: state.original,
+          evaluation: action.evaluation,
+        };
+      }
+      break;
+
+    case "choosing":
+      if (action.type === "choose") {
+        const chosen = state.evaluation.candidates[action.index];
+        if (!chosen) {
+          throw new Error("That sentence option does not exist.");
+        }
+        return { ...state, step: "generating-image", chosen };
+      }
+      break;
+
+    case "generating-image":
+      if (action.type === "receive-image") {
+        return {
+          ...state,
+          step: "image-ready",
+          imagePath: action.imagePath,
+          itemPath: action.itemPath,
+        };
+      }
+      break;
+
+    case "image-ready":
+      if (action.type === "start-quiz") {
+        return { ...state, step: "recalling" };
+      }
+      break;
+
+    case "recalling":
+      if (action.type === "submit-recall" && action.recall.trim()) {
+        return { ...state, step: "revealed", recall: action.recall.trim() };
+      }
+      break;
+
+    case "revealed":
+      break;
+  }
+
+  throw new Error(`Action ${action.type} is invalid during ${state.step}.`);
+}

--- a/skills/english-punch/SKILL.md
+++ b/skills/english-punch/SKILL.md
@@ -1,191 +1,75 @@
 ---
 name: english-punch
-description: English learning loop driven by the ep CLI. Capture unfamiliar vocabulary as flashcards, generate questions/hints/explanations from conversation context, and (later) run spaced-repetition reviews end-to-end from chat.
+description: Use the English Punch ep CLI from agent workflows; prefer ep help output as the source of truth and keep learning-content policy user-specific.
 ---
 
-# English Punch skill
+# English Punch Skill
 
-This skill turns a regular Claude Code chat into an English-learning
-coach backed by the [English Punch](https://englishpunch.vercel.app/)
-flashcard app. It uses the `ep` CLI (a Go binary distributed via
-Homebrew) as its tool surface and never calls any AI API directly —
-all content generation happens in this conversation, and `ep` is a
-thin wrapper around the Convex backend that stores the cards.
+This skill is a thin guide for using `ep`, the English Punch CLI. Treat
+the installed CLI help as the source of truth because command behavior
+can change independently of this skill.
 
-## When to use this skill
+## Source of Truth
 
-- The user pastes an English word or phrase they do not know.
-- The user says a sentence with an error and wants a correction.
-- The user asks for a flashcard review session.
-- The user asks "what does X mean" and you want the answer to stick.
+- Run `ep --help` when you need the command map.
+- Run `ep <command> --help` or `ep <command> <subcommand> --help` before
+  using an unfamiliar command.
+- Prefer `--json` with explicit fields for scripted calls. If a command
+  supports field discovery, bare `--json` prints the available fields.
+- Match errors by their leading `UPPER_SNAKE_CASE` token.
 
-## Prerequisites
+## Setup Checks
 
-Before using any `ep` tool, check the environment:
+Before using card, bag, or review commands:
 
-1. **Is `ep` installed?** — run `ep --version`. If missing, tell the
-   user to install via:
+1. Check the CLI:
+   ```bash
+   ep --version
+   ```
+   If it is missing:
    ```bash
    brew tap englishpunch/cli https://github.com/englishpunch/english-punch-app
    brew install englishpunch/cli/ep
    ```
-2. **Is the user logged in?** — run `ep auth status --json`. If the
-   exit code is `2` or the token is `NOT_LOGGED_IN`, ask the user to
-   run `ep auth login` themselves (it needs interactive input).
-3. **Is there a default bag?** — run
-   `ep bags default show --json defaultBagId`. If empty, list the
-   user's bags with `ep bags list --json _id,name`, ask them which
-   one to use, and set it with `ep bags default set <id>`.
 
-Every `ep` command supports `--json` for machine-readable output and
-every error starts with an `UPPER_SNAKE_CASE` token you can
-pattern-match on (see `docs/cli-llm-as-caller.md` in the repo for
-the full list).
+2. Check login state:
+   ```bash
+   ep auth status --json loggedIn,email,convexUrl
+   ```
+   If the user is not logged in, ask them to run `ep auth login`
+   themselves.
 
-## Creating a flashcard
+3. For card-scoped commands, check the default bag:
+   ```bash
+   ep bags default show --json defaultBagId
+   ```
+   If it is empty, list bags and ask which one to use:
+   ```bash
+   ep bags list --json _id,name
+   ep bags default set <bag-id>
+   ```
 
-When the user encounters an unfamiliar word or phrase, you (the
-skill, not the server) generate the four card fields directly and
-pass them to `ep cards create`. Do not ask the server to generate
-them — the CLI has no AI path and the web app's `generateCardDraft`
-action is for the web UI only.
+## Common Flows
 
-### Field rules
+- For bags, start with `ep bags --help`.
+- For cards, start with `ep cards --help`.
+- For auth/config/diagnostics, start with `ep auth --help`,
+  `ep config --help`, and `ep doctor --help`.
+- For review sessions, start with `ep review --help`. If the installed
+  CLI does not support the requested review workflow, direct the user to
+  the web app at `https://englishpunch.vercel.app/`.
 
-- **`answer`** (positional) — the target English word or phrase.
-  Keep the form the user will actually study. If the user provided
-  the base form but the question reads more naturally with an
-  inflected form (`apply` → `applied`), pick the inflected form
-  **as the answer** and mention the inflection in the explanation.
+Use mutations such as create, replace, delete, reserve, or rate only
+after the user clearly asks for that change. Inspect existing data with
+list/get-style commands before modifying it when that reduces ambiguity.
 
-- **`--question`** — a single fill-in-the-blank sentence with `___`
-  as the only blank. The answer must be the most natural completion.
-  Strongly prefer a real, high-frequency collocation or grammatical
-  frame for the target word, such as verb+noun, adjective+noun,
-  adverb+adjective, or a common preposition pattern. Let that
-  collocation make the answer feel inevitable; do not rely on a long
-  explanation-like setup. Avoid rare, poetic, or awkward combinations
-  even if they technically fit the meaning. Match the surrounding
-  words' register and tone to the target word and context
-  (formal/informal, academic, business, casual, emotional, etc.). Do
-  not mix slang with a formal target, or stiff wording with a casual
-  target, unless the context explicitly calls for that contrast. Keep
-  the sentence simple (CEFR B1–B2), concise, and easy to memorize as a
-  whole sentence. Prefer 8–22 words, counting the blank as one word;
-  shorter is acceptable when the collocation is still natural, but
-  avoid exceeding 22 words unless the context truly requires it. Do not
-  add extra background just to make the
-  sentence longer. If the user provided context, reflect the situation
-  or tone naturally without explaining the context.
+## Content Policy
 
-- **`--hint`** — 2–3 high-priority synonyms or paraphrases, preferably
-  comma-separated and under 12 words total. Do not include the answer
-  itself in the hint.
+The CLI stores caller-provided card content; it does not define the
+user's learning style. Do not bake a specific question-writing style,
+vocabulary level, collocation policy, correction style, or tutoring
+persona into this repo skill. Use the user's explicit request or their
+personal/project-specific skill for learning-content policy.
 
-- **`--explanation`** — 10–50 words total. Briefly say when the word
-  is appropriate and, when useful, contrast one close synonym by
-  nuance, tone, or intensity. Do not repeat the hint. If the user says
-  "description", treat it as this `explanation` field.
-
-### Generation workflow
-
-When generating or replacing `question`, `hint`, and `explanation`,
-delegate the content generation to a fresh subagent when subagent tools
-are available. Start it without conversation history and give it only:
-the answer, optional user/card context, and the field rules above.
-
-The subagent is a content generator only. It must not call `ep`, query
-Convex, edit files, or mutate any data. Ask it to return strict JSON:
-
-```json
-{
-  "question": "... ___ ...",
-  "hint": "...",
-  "explanation": "..."
-}
-```
-
-The parent agent validates the result before saving: exactly one `___`,
-8–22 question words unless context truly requires otherwise, natural
-collocation, answer is the best completion, hint is under 12 words and
-does not contain the answer, and explanation is 10–50 words. If the
-result is weak, ask a fresh subagent for a new draft or revise only minor
-issues locally. The parent agent alone calls `ep cards create` or
-`ep cards replace` and confirms the saved card.
-
-### Call shape
-
-```bash
-ep cards create "disheartened" \
-  --question "She was deeply ___ by the rejection letter." \
-  --hint "discouraged, dejected, low-spirited" \
-  --explanation "Use when someone has lost confidence or hope. It is stronger than 'sad' but less intense than 'devastated', and it sounds more formal than 'bummed'."
-```
-
-Pass `--bag <id>` only when the user explicitly names a different
-bag. Otherwise rely on the default set above.
-
-On success without `--json` the command prints a short confirmation.
-For scripted use add `--json` — success returns
-`{"ok": true, "bagId": "...", "question": "...", "answer": "...", "hint": "...", "explanation": "..."}`.
-
-If the call fails with `NOT_LOGGED_IN` or `NO_DEFAULT_BAG`, rerun the
-relevant Prerequisites step — do not auto-retry `cards create` on
-`NOT_LOGGED_IN`, since only the user can complete `ep auth login`.
-
-## Finding and replacing cards
-
-With `ep` 0.3.4 or newer, use `ep cards list` to find cards inside a
-bag before replacing them. It mirrors the web card list:
-
-```bash
-ep cards list --bag <bag-id> --search "precision" --json page,count,isDone,continueCursor
-ep cards list --bag <bag-id> --limit 50 --cursor <continueCursor> --json page,continueCursor,isDone
-```
-
-`--search` uses the web app's answer search index only; it does not
-search questions, hints, explanations, or arbitrary text. The response
-contains `page` with card objects whose IDs are in `_id`, plus
-`continueCursor` and `isDone` for pagination. Once the target `_id` is
-known, call `ep cards get <card-id> --bag <bag-id> --json` before
-`ep cards replace`. Remember that `ep cards replace` resets the card's
-FSRS schedule.
-
-## Reviewing flashcards (planned)
-
-The spaced-repetition review loop (`ep review start / reveal / rate`)
-is designed in `thoughts/plans/2026-04-11-server-side-review-attempt.md`
-but not yet implemented. Until those commands ship, direct the user
-to the web app at https://englishpunch.vercel.app/ for review
-sessions.
-
-## Conversation style
-
-- Evaluate the user's English on every message (0–100 scale:
-  clarity, grammar, naturalness, correctness). Skip the correction
-  if the score exceeds 90.
-- Offer two rewrites — casual and formal — for the user's own
-  sentences, not for the flashcard content you generate.
-- Include IPA pronunciation for words the user is likely to
-  mispronounce.
-- When the user asks to save a word as a card, do not lecture on
-  meaning before saving. Generate the card, call `ep cards create`,
-  then briefly explain what you captured.
-
-## What this skill deliberately does not do
-
-- **Call any AI action on the server.** Question, hint, and explanation
-  generation happens in this chat using the rules above. The
-  `convex/ai.ts` actions exist for the web app, not for the CLI.
-- **Store cards without the user noticing.** Always confirm the card
-  was created by printing the question and answer after the mutation
-  succeeds.
-- **Run interactive prompts in `ep`.** Every command supports
-  non-interactive flag-based invocation, which is the only mode this
-  skill uses.
-
-## References
-
-- CLI rule set: `docs/cli-llm-as-caller.md`
-- `ep` source: https://github.com/englishpunch/english-punch-app/tree/main/cli
-- Server-side AI rules we mirror: `convex/ai.ts`
+Do not call English Punch server-side AI actions directly from this
+skill. Use the public `ep` commands exposed by the CLI.


### PR DESCRIPTION
## What changed

- Carries forward the local English Punch skill simplification commit for #69.
- Adds a throwaway sentence -> image -> recall prototype for #73.
- Adds a `prototype:sentence-image` script, ignored `.poc-data` storage, per-item JSON/PNG output, and ChatGPT browser automation.
- Allows the macOS `open` binary in Knip because the prototype uses it to view cue images.

## Why

This lets us test whether choosing a whole rewritten sentence and memorizing it through a text-free image cue feels useful before adding anything to the real English Punch product.

## Validation

- `ep --version` -> `ep version 0.3.5`
- `brew info englishpunch/cli/ep` -> stable and installed `0.3.5`
- `pnpm exec prettier --check package.json knip.jsonc prototypes/sentence-image-workflow/*.ts prototypes/sentence-image-workflow/*.md`
- `pnpm exec tsc --noEmit --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --allowImportingTsExtensions --types node prototypes/sentence-image-workflow/*.ts`
- `pnpm run check`