### PR TITLE
Unify English Punch product version at 0.3.5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,6 +49,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # --- Pre-commit checks (safe with staged changes) ---
+      - name: Version consistency
+        id: version
+        run: pnpm run check:version
+        continue-on-error: true
+
       - name: Lint
         id: lint
         run: pnpm run lint
@@ -90,6 +95,7 @@ jobs:
           }
 
           check_step "lint" "${{ steps.lint.outcome }}" "pnpm run lint"
+          check_step "version" "${{ steps.version.outcome }}" "pnpm run check:version"
           check_step "knip" "${{ steps.knip.outcome }}" "pnpm run knip"
           check_step "test" "${{ steps.test.outcome }}" "CI=true pnpm run test"
           check_step "dedupe" "${{ steps.dedupe.outcome }}" "pnpm dedupe --check"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      product-version: ${{ steps.product-version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +29,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Resolve English Punch version
+        id: product-version
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -44,6 +52,8 @@ jobs:
           tags: |
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.version=${{ steps.product-version.outputs.version }}
 
       - name: Build and push frontend
         uses: docker/build-push-action@v6
@@ -65,6 +75,9 @@ jobs:
           tags: |
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.version=${{ steps.product-version.outputs.version }}
+            org.opencontainers.image.title=english-punch-mcp
 
       - name: Build and push MCP server
         uses: docker/build-push-action@v6
@@ -147,15 +160,18 @@ jobs:
           git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           gh auth setup-git
 
-      - name: Update English Punch image tags
+      - name: Update English Punch deployment metadata
         if: steps.infra-app-config.outputs.configured == 'true'
         working-directory: infra
         env:
           IMAGE_TAG: ${{ steps.image.outputs.tag }}
+          PRODUCT_VERSION: ${{ needs.build.outputs.product-version }}
         run: >-
           node ../scripts/update-infra-images.mjs
           apps/english-punch/values.yaml
+          apps/english-punch/Chart.yaml
           "$IMAGE_TAG"
+          "$PRODUCT_VERSION"
 
       - name: Open infra image update PR
         if: steps.infra-app-config.outputs.configured == 'true'
@@ -164,14 +180,15 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: bot/update-english-punch-${{ github.sha }}
           IMAGE_TAG: ${{ steps.image.outputs.tag }}
+          PRODUCT_VERSION: ${{ needs.build.outputs.product-version }}
         run: |
-          if git diff --quiet -- apps/english-punch/values.yaml; then
-            echo "Infra already uses ${IMAGE_TAG}; skipping PR."
+          if git diff --quiet -- apps/english-punch/values.yaml apps/english-punch/Chart.yaml; then
+            echo "Infra already uses ${IMAGE_TAG} and English Punch ${PRODUCT_VERSION}; skipping PR."
             exit 0
           fi
 
           git checkout -b "$BRANCH"
-          git add apps/english-punch/values.yaml
+          git add apps/english-punch/values.yaml apps/english-punch/Chart.yaml
           git commit -m "Update English Punch images to ${IMAGE_TAG}"
           git push origin "$BRANCH"
 
@@ -180,4 +197,4 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "Update English Punch images to ${IMAGE_TAG}" \
-            --body "Updates the English Punch frontend and MCP images to \`${IMAGE_TAG}\` after englishpunch/english-punch-app@${{ github.sha }}."
+            --body "Updates English Punch to \`${PRODUCT_VERSION}\` and advances the frontend and MCP images to \`${IMAGE_TAG}\` after englishpunch/english-punch-app@${{ github.sha }}."

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify release version
+        run: |
+          release_version="${GITHUB_REF_NAME#v}"
+          package_version="$(node -p "require('../package.json').version")"
+          if [[ "$release_version" != "$package_version" ]]; then
+            echo "Tag version ${release_version} does not match English Punch ${package_version}." >&2
+            exit 1
+          fi
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: cli/go.mod

--- a/convex/router.test.ts
+++ b/convex/router.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment edge-runtime
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { expect, it } from "vitest";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+it("reports the canonical English Punch version from backend health", async () => {
+  const t = convexTest(schema, modules);
+
+  const response = await t.fetch("/health");
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({
+    status: "ok",
+    version: "0.3.5",
+    timestamp: expect.any(Number),
+  });
+});
+
+it("exposes the canonical English Punch backend version", async () => {
+  const t = convexTest(schema, modules);
+
+  const response = await t.fetch("/version");
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ version: "0.3.5" });
+});

--- a/convex/router.ts
+++ b/convex/router.ts
@@ -5,6 +5,7 @@ import {
   oauthPublicJwk,
 } from "./oauthConfig";
 import { token } from "./oauthHttp";
+import { ENGLISH_PUNCH_VERSION } from "../src/lib/version";
 
 const http = httpRouter();
 
@@ -33,13 +34,25 @@ http.route({
 
 http.route({ path: "/oauth/token", method: "POST", handler: token });
 
+http.route({
+  path: "/version",
+  method: "GET",
+  handler: httpAction(async () =>
+    jsonResponse({ version: ENGLISH_PUNCH_VERSION })
+  ),
+});
+
 // Health check endpoint
 http.route({
   path: "/health",
   method: "GET",
   handler: httpAction(async () => {
     return new Response(
-      JSON.stringify({ status: "ok", timestamp: Date.now() }),
+      JSON.stringify({
+        status: "ok",
+        version: ENGLISH_PUNCH_VERSION,
+        timestamp: Date.now(),
+      }),
       {
         status: 200,
         headers: {

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,32 @@
+# English Punch versioning
+
+English Punch uses one public product version in `x.x.x` format. The canonical
+source is the root `package.json`. For version `0.3.5`, the same value appears
+at these public seams:
+
+- `ep --version` in a tagged CLI release
+- MCP initialization and `GET /healthz`
+- application backend `GET /health` and `GET /version`
+- the version shown at the bottom of the frontend profile drawer
+- root and MCP package metadata
+- container `org.opencontainers.image.version` labels
+- the Argo CD Helm chart's `appVersion`
+
+Run `pnpm run check:version` to verify that package metadata agrees. The CLI
+release workflow also requires the Git tag, after removing a leading `v`, to
+match the root package version.
+
+## Versions and revisions
+
+The product version describes the English Punch release. Deployment revisions
+remain independent and immutable:
+
+- Frontend and MCP images use `sha-<commit>` tags.
+- The self-hosted Convex image stays pinned to its own upstream revision.
+- The Helm chart package `version` tracks chart packaging changes, while
+  `appVersion` tracks the English Punch product version.
+
+The Docker workflow publishes the images and opens one automated infra PR that
+updates both SHA image tags and `appVersion`. Argo CD deploys the merged infra
+change. The Convex `engineRevision` annotation is operational metadata and must
+not be presented as the English Punch product version.

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/mcp-server/node_modules ./mcp-server/node_modules
 COPY --from=build /app/mcp-server/dist ./mcp-server/dist
 COPY --from=build /app/mcp-server/package.json ./mcp-server/package.json

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -54,6 +54,12 @@ curl http://localhost:3001/.well-known/oauth-protected-resource/mcp \
   -H 'Host: mcp-ep.echoja.com'
 ```
 
+The health response includes the canonical English Punch product version:
+
+```json
+{"status":"ok","version":"0.3.5"}
+```
+
 ## Build and deploy the container
 
 Build from the repository root because the MCP package copies the generated
@@ -67,9 +73,10 @@ docker run --rm -p 3001:3001 --env-file mcp-server/.env.local \
 
 On every merge to `main`, `.github/workflows/docker.yml` builds the frontend
 and MCP images for `linux/amd64` and `linux/arm64`, publishes both to GHCR with
-the same `sha-<commit>` tag, and opens one infra PR that advances both image
-tags. The Argo CD-managed Helm chart in `echoja/infra/apps/english-punch` owns
-the MCP Deployment, Service, and Ingress resources.
+the same `sha-<commit>` tag and product-version OCI label, and opens one infra
+PR that advances both image tags and the Helm `appVersion`. The Argo CD-managed
+Helm chart in `echoja/infra/apps/english-punch` owns the MCP Deployment,
+Service, and Ingress resources.
 
 For the first deployment, merge the infra chart scaffold while `mcp.enabled`
 is still `false`, then merge the app change. The app's `main` build publishes

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@english-punch/mcp-server",
-  "version": "0.1.0",
+  "version": "0.3.5",
   "description": "MCP server for English Punch — vocabulary learning tools",
   "type": "module",
   "bin": {

--- a/mcp-server/src/http-server.test.ts
+++ b/mcp-server/src/http-server.test.ts
@@ -17,6 +17,27 @@ afterEach(() => {
 });
 
 describe("English Punch MCP HTTP server", () => {
+  it("reports the canonical version from the health endpoint", async () => {
+    const config = loadServerConfig({
+      MCP_ALLOWED_HOSTS: "127.0.0.1",
+    });
+    const server = createMcpHttpServer(config, {
+      authenticate: async () => {
+        throw new Error("authentication should not run for health checks");
+      },
+    });
+    openServers.push(server);
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve)
+    );
+    const { port } = server.address() as AddressInfo;
+
+    const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "ok", version: "0.3.5" });
+  });
+
   it("serves OAuth protected-resource discovery without authentication", async () => {
     const config = loadServerConfig({
       MCP_ALLOWED_HOSTS: "127.0.0.1",

--- a/mcp-server/src/http-server.ts
+++ b/mcp-server/src/http-server.ts
@@ -12,6 +12,7 @@ import type { AuthenticatedRequest } from "./oauth.js";
 import type { ServerConfig } from "./config.js";
 import { bearerChallenge, protectedResourceMetadata } from "./oauth.js";
 import { createEnglishPunchServer } from "./server.js";
+import { ENGLISH_PUNCH_VERSION } from "./version.js";
 
 type AuthenticationResult = {
   auth: AuthenticatedRequest;
@@ -134,7 +135,10 @@ export const createMcpHttpServer = (
     }
 
     if (request.method === "GET" && pathname === "/healthz") {
-      sendJson(response, 200, { status: "ok" });
+      sendJson(response, 200, {
+        status: "ok",
+        version: ENGLISH_PUNCH_VERSION,
+      });
       return;
     }
 

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -19,6 +19,11 @@ describe("English Punch MCP tools", () => {
       client.connect(clientTransport),
     ]);
 
+    expect(client.getServerVersion()).toEqual({
+      name: "english-punch",
+      version: "0.3.5",
+    });
+
     const { tools } = await client.listTools();
     const createCard = tools.find((tool) => tool.name === "create-card");
     const updateCard = tools.find((tool) => tool.name === "update-card");

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -7,6 +7,7 @@ import { registerCardTools } from "./tools/cards.js";
 import { registerLearningTools } from "./tools/learning.js";
 import { resultContent } from "./tools/result.js";
 import { registerStatsTools } from "./tools/stats.js";
+import { ENGLISH_PUNCH_VERSION } from "./version.js";
 
 export const createEnglishPunchServer = (
   client: ConvexHttpClient,
@@ -16,7 +17,7 @@ export const createEnglishPunchServer = (
   const server = new McpServer(
     {
       name: "english-punch",
-      version: "0.2.0",
+      version: ENGLISH_PUNCH_VERSION,
     },
     {
       instructions:

--- a/mcp-server/src/version.ts
+++ b/mcp-server/src/version.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+) as { version?: unknown };
+
+if (
+  typeof packageJson.version !== "string" ||
+  !/^\d+\.\d+\.\d+$/.test(packageJson.version)
+) {
+  throw new Error("English Punch package version must use x.x.x format");
+}
+
+export const ENGLISH_PUNCH_VERSION = packageJson.version;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "english-punch-app",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.3.5",
   "type": "module",
   "scripts": {
     "dev": "npm-run-all --parallel dev:frontend dev:backend",
@@ -21,6 +21,7 @@
     "change-password": "tsx src/scripts/changePassword.ts",
     "check": "./scripts/check-local.sh",
     "check:all": "./scripts/check-local.sh --all",
+    "check:version": "node scripts/check-version-consistency.mjs",
     "sync:humanlayer": "./sync-humanlayer-claude-config.sh",
     "prepare": "husky"
   },

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -42,6 +42,7 @@ run_and_capture() {
 set +e
 
 # --- Pre-commit checks (safe with staged changes) ---
+run_and_capture "version" pnpm run check:version
 run_and_capture "lint" pnpm run lint
 run_and_capture "knip" pnpm run knip
 run_and_capture "test" env CI=true pnpm run test

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -1,0 +1,21 @@
+import { readFile } from "node:fs/promises";
+
+const readJson = async (path) => JSON.parse(await readFile(path, "utf8"));
+
+const rootPackage = await readJson(new URL("../package.json", import.meta.url));
+const mcpPackage = await readJson(
+  new URL("../mcp-server/package.json", import.meta.url)
+);
+const version = rootPackage.version;
+
+if (typeof version !== "string" || !/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error("Root package version must use x.x.x format");
+}
+
+if (mcpPackage.version !== version) {
+  throw new Error(
+    `MCP package version ${mcpPackage.version} does not match ${version}`
+  );
+}
+
+console.log(`English Punch version ${version} is consistent`);

--- a/scripts/update-infra-images.mjs
+++ b/scripts/update-infra-images.mjs
@@ -55,17 +55,34 @@ export const updateEnglishPunchValues = (content, imageTag) => {
   return lines.join("\n");
 };
 
+export const updateEnglishPunchChart = (content, version) => {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`Invalid English Punch version: ${version}`);
+  }
+
+  const appVersionFields = content.match(/^appVersion:\s*.*$/gm) ?? [];
+  if (appVersionFields.length !== 1) {
+    throw new Error("Expected exactly one Helm appVersion field");
+  }
+
+  return content.replace(/^appVersion:\s*.*$/m, `appVersion: "${version}"`);
+};
+
 const isCli =
   process.argv[1] !== undefined &&
   import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isCli) {
-  const [, , valuesPath, imageTag] = process.argv;
-  if (!valuesPath || !imageTag) {
+  const [, , valuesPath, chartPath, imageTag, version] = process.argv;
+  if (!valuesPath || !chartPath || !imageTag || !version) {
     throw new Error(
-      "Usage: update-infra-images.mjs <values.yaml path> <sha-image-tag>"
+      "Usage: update-infra-images.mjs <values.yaml path> <Chart.yaml path> <sha-image-tag> <x.x.x version>"
     );
   }
-  const content = readFileSync(valuesPath, "utf8");
-  writeFileSync(valuesPath, updateEnglishPunchValues(content, imageTag));
+  const values = readFileSync(valuesPath, "utf8");
+  const chart = readFileSync(chartPath, "utf8");
+  const updatedValues = updateEnglishPunchValues(values, imageTag);
+  const updatedChart = updateEnglishPunchChart(chart, version);
+  writeFileSync(valuesPath, updatedValues);
+  writeFileSync(chartPath, updatedChart);
 }

--- a/scripts/update-infra-images.test.mjs
+++ b/scripts/update-infra-images.test.mjs
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { updateEnglishPunchValues } from "./update-infra-images.mjs";
+import {
+  updateEnglishPunchChart,
+  updateEnglishPunchValues,
+} from "./update-infra-images.mjs";
 
 const values = `frontend:
   image:
@@ -17,6 +20,12 @@ mcp:
 backend:
   image:
     tag: unchanged
+`;
+
+const chart = `apiVersion: v2
+name: english-punch
+version: 0.1.0
+appVersion: "0.1.0"
 `;
 
 describe("updateEnglishPunchValues", () => {
@@ -38,5 +47,30 @@ describe("updateEnglishPunchValues", () => {
     expect(() => updateEnglishPunchValues(values, "main")).toThrow(
       "Invalid image tag"
     );
+  });
+});
+
+describe("updateEnglishPunchChart", () => {
+  it("updates the English Punch appVersion without changing the chart version", () => {
+    expect(updateEnglishPunchChart(chart, "0.3.5")).toBe(`apiVersion: v2
+name: english-punch
+version: 0.1.0
+appVersion: "0.3.5"
+`);
+  });
+
+  it("rejects a non-SemVer product version", () => {
+    expect(() => updateEnglishPunchChart(chart, "main")).toThrow(
+      "Invalid English Punch version"
+    );
+  });
+
+  it("rejects missing or duplicate appVersion fields", () => {
+    expect(() =>
+      updateEnglishPunchChart(chart.replace(/^appVersion:.*$/m, ""), "0.3.5")
+    ).toThrow("Expected exactly one Helm appVersion field");
+    expect(() =>
+      updateEnglishPunchChart(`${chart}appVersion: "9.9.9"\n`, "0.3.5")
+    ).toThrow("Expected exactly one Helm appVersion field");
   });
 });

--- a/src/components/AppVersion.test.tsx
+++ b/src/components/AppVersion.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import { expect, it } from "vitest";
+import { AppVersion } from "./AppVersion";
+
+it("shows the canonical English Punch version", () => {
+  render(<AppVersion />);
+
+  expect(
+    screen.getByLabelText("English Punch version 0.3.5")
+  ).toHaveTextContent("v0.3.5");
+});

--- a/src/components/AppVersion.tsx
+++ b/src/components/AppVersion.tsx
@@ -1,0 +1,12 @@
+import { ENGLISH_PUNCH_VERSION } from "@/lib/version";
+
+export function AppVersion() {
+  return (
+    <span
+      aria-label={`English Punch version ${ENGLISH_PUNCH_VERSION}`}
+      className="font-mono text-xs text-gray-600"
+    >
+      v{ENGLISH_PUNCH_VERSION}
+    </span>
+  );
+}

--- a/src/components/MobileShell.tsx
+++ b/src/components/MobileShell.tsx
@@ -19,6 +19,7 @@ import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { useTranslation } from "react-i18next";
 import { languageOptions } from "@/i18n";
+import { AppVersion } from "./AppVersion";
 
 interface MobileShellProps {
   children?: React.ReactNode;
@@ -263,10 +264,11 @@ function ProfileDrawer({
             </Select>
           </div>
         </div>
-        <div className="mt-auto">
+        <div className="mt-auto flex items-center justify-between">
           <Button variant="secondary" size="sm" onClick={() => void signOut()}>
             {t("common.actions.signOut")}
           </Button>
+          <AppVersion />
         </div>
       </div>
     </div>

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,3 @@
+import packageJson from "../../package.json";
+
+export const ENGLISH_PUNCH_VERSION = packageJson.version;


### PR DESCRIPTION
## What changed
- use 0.3.5 across CLI release validation, MCP initialization and health, backend health/version, packages, and frontend display
- publish OCI version labels and update Helm appVersion with image SHAs through one automated infra PR
- keep deployment and Convex engine revisions separate
- add consistency checks, tests, and versioning documentation

## Verification
- 67 Vitest tests
- frontend and MCP production builds
- Convex typecheck
- ESLint, Knip, and package dedupe
- Go test and vet; release-style ep --version reports 0.3.5
- Helm lint and Kubernetes server-side dry-run

Tracks #83.