### PR TITLE
Avoid the reserved Convex version path

### DIFF
--- a/convex/router.test.ts
+++ b/convex/router.test.ts
@@ -20,10 +20,10 @@ it("reports the canonical English Punch version from backend health", async () =
   });
 });
 
-it("exposes the canonical English Punch backend version", async () => {
+it("exposes the canonical version at the ingress rewrite target", async () => {
   const t = convexTest(schema, modules);
 
-  const response = await t.fetch("/version");
+  const response = await t.fetch("/api/version");
 
   expect(response.status).toBe(200);
   expect(await response.json()).toEqual({ version: "0.3.5" });

--- a/convex/router.ts
+++ b/convex/router.ts
@@ -35,7 +35,7 @@ http.route({
 http.route({ path: "/oauth/token", method: "POST", handler: token });
 
 http.route({
-  path: "/version",
+  path: "/api/version",
   method: "GET",
   handler: httpAction(async () =>
     jsonResponse({ version: ENGLISH_PUNCH_VERSION })

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -30,3 +30,7 @@ The Docker workflow publishes the images and opens one automated infra PR that
 updates both SHA image tags and `appVersion`. Argo CD deploys the merged infra
 change. The Convex `engineRevision` annotation is operational metadata and must
 not be presented as the English Punch product version.
+
+The self-hosted Convex engine reserves its own root `/version` path. Traefik
+therefore preserves the public application endpoint `GET /version` while
+rewriting it to the application-owned Convex HTTP action at `GET /api/version`.


### PR DESCRIPTION
## What changed
- move the application-owned version HTTP action to `/api/version`
- document that the public `/version` seam is provided by an ingress rewrite
- update the backend route test

Self-hosted Convex reserves root `/version` for its engine, so application routing cannot override it directly.

## Verification
- focused Convex router tests
- ESLint
- Convex TypeScript check

Tracks #83.